### PR TITLE
removed JSON stringify and parse on postMessage objects

### DIFF
--- a/weevil.js
+++ b/weevil.js
@@ -5,7 +5,7 @@ function emitterFor (scope) {
 
     var onMessage = function (message) {
         var cbs;
-        message = JSON.parse(message.data);
+        message = message.data;
 
         if (!message.weevil) return;
 
@@ -50,11 +50,11 @@ function emitterFor (scope) {
         emit: function (name /*, [args...] */) {
             var args = Array.prototype.slice.call(arguments);
 
-            scope.postMessage(JSON.stringify({
+            scope.postMessage({
                 name: args.shift(),
                 args: args,
                 weevil: true
-            }));
+            });
 
             return this;
         },


### PR DESCRIPTION
I'm using weevil to pass an ImageData object to a worker for processing, but transferring via JSON doesn't work with complex objects. `postMessage` now supports [structured objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) to handle this, so I've removed the JSON parse and stringify wrappers. I tried adding additional tests but continued to get _ReferenceError: Blob is not defined_, even with updated devDependencies.... maybe I'm missing something though!

Would love to see this update on npm if you decide to merge. 
Cheers!